### PR TITLE
AQ-458 - Handle Auth headers with "Bearer " preceding the token

### DIFF
--- a/src/JwtGuard/JwtTokenAuthenticator.php
+++ b/src/JwtGuard/JwtTokenAuthenticator.php
@@ -19,6 +19,7 @@ class JwtTokenAuthenticator implements RequestAuthoriser, IdentityProvider
     const EXPIRY = 'exp';
     const IS_ADMIN = 'isAdmin';
     const SEGMENTS = 'segments';
+    const BEARER = 'Bearer ';
 
     /**
      * @var AlgorithmInterface
@@ -98,7 +99,7 @@ class JwtTokenAuthenticator implements RequestAuthoriser, IdentityProvider
         $context = new Context( EncryptionFactory::create( $this->algorithm ) );
 
         if ( $header ) {
-            $this->token = $this->jwt->deserialize( $header );
+            $this->token = $this->jwt->deserialize( $this->extractJwtFromHeader($header) );
         }
 
         if ( $this->algorithm instanceof None ) {
@@ -149,5 +150,13 @@ class JwtTokenAuthenticator implements RequestAuthoriser, IdentityProvider
     {
         $segments = $this->getClaimOrNull( self::SEGMENTS );
         return is_array( $segments ) ? $segments : [ ];
+    }
+
+    private function extractJwtFromHeader( $header )
+    {
+        if( strpos( $header, self::BEARER ) !== false ){
+            return substr( $header, strlen( self::BEARER ) );
+        }
+        return $header;
     }
 }

--- a/src/JwtGuard/JwtTokenAuthenticator.php
+++ b/src/JwtGuard/JwtTokenAuthenticator.php
@@ -99,7 +99,11 @@ class JwtTokenAuthenticator implements RequestAuthoriser, IdentityProvider
         $context = new Context( EncryptionFactory::create( $this->algorithm ) );
 
         if ( $header ) {
-            $this->token = $this->jwt->deserialize( $this->extractJwtFromHeader($header) );
+            try{
+                $this->token = $this->jwt->deserialize( $this->extractJwtFromHeader($header) );
+            } catch ( \Exception $e ){
+                return false;
+            }
         }
 
         if ( $this->algorithm instanceof None ) {
@@ -154,7 +158,11 @@ class JwtTokenAuthenticator implements RequestAuthoriser, IdentityProvider
 
     private function extractJwtFromHeader( $header )
     {
+<<<<<<< Updated upstream
         if( strpos( $header, self::BEARER ) !== false ){
+=======
+        if( strpos( $header, self::BEARER ) === 0 ){
+>>>>>>> Stashed changes
             return substr( $header, strlen( self::BEARER ) );
         }
         return $header;

--- a/src/JwtGuard/JwtTokenAuthenticator.php
+++ b/src/JwtGuard/JwtTokenAuthenticator.php
@@ -158,11 +158,7 @@ class JwtTokenAuthenticator implements RequestAuthoriser, IdentityProvider
 
     private function extractJwtFromHeader( $header )
     {
-<<<<<<< Updated upstream
-        if( strpos( $header, self::BEARER ) !== false ){
-=======
         if( strpos( $header, self::BEARER ) === 0 ){
->>>>>>> Stashed changes
             return substr( $header, strlen( self::BEARER ) );
         }
         return $header;

--- a/test/JwtTokenAuthenticatorTest.php
+++ b/test/JwtTokenAuthenticatorTest.php
@@ -336,6 +336,14 @@ class JwtTokenAuthenticatorTest extends \PHPUnit_Framework_TestCase
      */
     public function givenValidTokenAndBearerStringPresentInRequestHeader_WhenCallingIsAuthorised_ThenAuthorisationPasses()
     {
-        $this->auth->isAuthorised( new MockTokenRequest( "Bearer ". $this->serialiseToken( $this->getValidToken() ) ) );
+        $this->assertTrue( $this->auth->isAuthorised( new MockTokenRequest( "Bearer ". $this->serialiseToken( $this->getValidToken() ) ) ) );
+    }
+
+    /**
+     * @test
+     */
+    public function givenValidTokenButHeaderIsInvalid_WhenCallingIsAuthorised_ThenAuthorisationFails()
+    {
+        $this->assertFalse( $this->auth->isAuthorised( new MockTokenRequest( " 🐟 should be broken ". $this->serialiseToken( $this->getValidToken() ) ) ) );
     }
 }

--- a/test/JwtTokenAuthenticatorTest.php
+++ b/test/JwtTokenAuthenticatorTest.php
@@ -176,8 +176,16 @@ class JwtTokenAuthenticatorTest extends \PHPUnit_Framework_TestCase
      */
     private function authoriseToken( Token $token )
     {
-        $serialised = ( new Jwt )->serialize( $token, EncryptionFactory::create( $this->algorithm ) );
-        return $this->auth->isAuthorised( new MockTokenRequest( $serialised ) );
+        return $this->auth->isAuthorised( new MockTokenRequest( $this->serialiseToken( $token ) ) );
+    }
+
+    /**
+     * @param $token
+     * @return string
+     */
+    private function serialiseToken( $token )
+    {
+        return ( new Jwt )->serialize( $token, EncryptionFactory::create( $this->algorithm ) );
     }
 
     /**
@@ -321,5 +329,13 @@ class JwtTokenAuthenticatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(self::USER_ID, $this->auth->getUserId());
         $this->assertEquals(self::IS_ADMIN, $this->auth->getIsAdmin());
         $this->assertEquals($this->testSegments, $this->auth->getSegments());
+    }
+
+    /**
+     * @test
+     */
+    public function givenValidTokenAndBearerStringPresentInRequestHeader_WhenCallingIsAuthorised_ThenAuthorisationPasses()
+    {
+        $this->auth->isAuthorised( new MockTokenRequest( "Bearer ". $this->serialiseToken( $this->getValidToken() ) ) );
     }
 }


### PR DESCRIPTION
From [jwt.io](jwt.io)
![image](https://cloud.githubusercontent.com/assets/6156549/21844792/e2d5c1c4-d7e7-11e6-8ffd-c320e82fcde6.png)

The header should be in the above format, this change adds backwards compatible support for that